### PR TITLE
Fix typo in MainActivity comment

### DIFF
--- a/android/app/src/main/java/com/sbabadag/komsudanal/MainActivity.kt
+++ b/android/app/src/main/java/com/sbabadag/komsudanal/MainActivity.kt
@@ -31,7 +31,7 @@ class MainActivity : ReactActivity() {
 
   /**
    * Returns the instance of the [ReactActivityDelegate]. We use [DefaultReactActivityDelegate]
-   * which allows you to enable New Architecture with a single boolean flags [fabricEnabled]
+   * which allows you to enable New Architecture with a single boolean flag [fabricEnabled]
    */
   override fun createReactActivityDelegate(): ReactActivityDelegate {
     return ReactActivityDelegateWrapper(


### PR DESCRIPTION
## Summary
- fix singular usage for `flag` in MainActivity comment

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684802de8b0483268c9916ebafc6843b